### PR TITLE
Install .NET 7 and 8 durign build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,9 @@ jobs:
     - name: Setup DotNet
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '7.0.x'
+        dotnet-version: | 
+          6.x
+          8.x
 
     - name: Restore Tools
       run: dotnet tool restore


### PR DESCRIPTION
Nvika requires .NET 6 still, will need to eventually replace it, but for now install it side by side with .NET 8.